### PR TITLE
Favorites

### DIFF
--- a/pimame_files/menu.py
+++ b/pimame_files/menu.py
@@ -213,7 +213,7 @@ def runmenu(menu, parent):
       # finished updating screen
 
     x = screen.getch() # Gets user input
-    if x == ord('\n') or x == ord(' ') or x == ord('a'):
+    if x == ord('\n'):
       x = ord('c')
 
     # What is user input?

--- a/pimame_files/menu.py
+++ b/pimame_files/menu.py
@@ -6,15 +6,21 @@
 
 import subprocess
 import curses, os #curses is the interface for capturing key presses on the menu, os launches the files
+from os import listdir
+from os.path import isfile, join
+import re
+import pickle
+
 screen = curses.initscr() #initializes a new window for capturing key presses
 curses.noecho() # Disables automatic echoing of key presses (prevents program from input each key twice)
 curses.cbreak() # Disables line buffering (runs each key as it is pressed rather than waiting for the return key to pressed)
 curses.start_color() # Lets you use colors when highlighting selected menu option
 screen.keypad(1) # Capture input from keypad
 
+topLineNum = 0
+
 wlan = subprocess.check_output("/sbin/ifconfig wlan0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}' ", shell=True)
 ether = subprocess.check_output("/sbin/ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}' ", shell=True)
-
 myip = ''
 if wlan != '':
   myip += wlan
@@ -30,12 +36,76 @@ curses.init_pair(1,curses.COLOR_BLACK, curses.COLOR_WHITE) # Sets up color pair 
 h = curses.color_pair(1) #h is the coloring for a highlighted menu option
 n = curses.A_NORMAL #n is the coloring for a non highlighted menu option
 
+DOWN = 1
+UP = -1
+OFFSET = 6
 MENU = "menu"
 COMMAND = "command"
+EMU_CONTEXT = {
+  'snes': {
+      'dir': '/home/pi/roms/snes',
+      'command': '/home/pi/emulators/pisnes/snes9x'
+  },
+  'genesis': {
+      'dir': '/home/pi/roms/genesis',
+      'command': '/home/pi/emulators/dgen-sdl-1.32/dgen'
+  }
+}
 
+FAV_PATH = '/home/pi/fav.pkl'
+
+def load_favorites():
+  fav = []
+  try:
+    with open(FAV_PATH, 'rb') as pkl_file:
+      fav = pickle.load(pkl_file)
+  except IOError:
+    pass
+  return fav
+
+def update_favorites(menu, parent, pos, is_add):
+  if len(menu['options']) > pos and menu['options'][pos]['type'] == COMMAND:
+    is_saved = -1
+    i = 0
+    for it in fav:
+      if menu['options'][pos]['title'] == it['title']:
+        is_saved = i
+      i = i + 1
+    
+    need_update = False
+    if is_add and is_saved == -1:
+      fav.append(menu['options'][pos])
+      need_update = True
+    elif is_add == False and is_saved > -1:
+      del fav[is_saved]
+      need_update = True
+
+    if (need_update):
+      try:
+        with open(FAV_PATH, 'wb+') as pkl_file:
+          pickle.dump(fav, pkl_file)
+      except IOError:
+        pass
+      menu_data['options'][fav_idx]['options'] = fav
+      if not is_add:
+        #runmenu(menu,parent)
+  #processmenu(menu_data)
+        return True
+  return False
+
+fav = load_favorites()
+fav_idx = 5
+
+def build_roms_menu(emulator):
+  retval = [ {
+  'title': f, 'type': COMMAND, 'command': EMU_CONTEXT[emulator]['command'] + ' \'' + EMU_CONTEXT[emulator]['dir'] + '/' + f +'\'' 
+  } for f in listdir(EMU_CONTEXT[emulator]['dir']) if isfile(join(EMU_CONTEXT[emulator]['dir'],f)) ]
+
+# print(retval)
+  return retval
 
 menu_data = {
-  'title': "PiMAME Menu (v0.7.10)", 'type': MENU, 'subtitle':  "Please select an option...",
+  'title': "PiMAME Menu (v0.7.9)", 'type': MENU, 'subtitle':  "Please select an option...",
   'options': [
     { 'title': "Arcade", 'type': MENU, 'subtitle': "Arcade Emulators",
     'options': [
@@ -48,16 +118,16 @@ menu_data = {
     { 'title': "Consoles", 'type': MENU, 'subtitle': "Console Emulators",
     'options': [
       { 'title': "PlayStation 1 (PCSX_ReARMed)", 'type': COMMAND, 'command': '/home/pi/emulators/pcsx_rearmed/pcsx' },
-      { 'title': "Genesis (DGen)", 'type': COMMAND, 'command': 'advmenu -cfg advmenu-dgen.rc' },
-      { 'title': "Nintendo Emulators", 'type': MENU, 'subtitle': 'Nintendo Emulators',
-      'options': [
-          { 'title': "SNES (PiSNES / SNES9x Advmenu)", 'type': COMMAND, 'command': 'advmenu -cfg advmenu-snes.rc' },
-          { 'title': "NES (AdvanceMESS)", 'type': COMMAND, 'command': 'advmenu -cfg advmenu-nes.rc' },
-          { 'title': "Gameboy (Gearboy Advmenu)", 'type': COMMAND, 'command': 'advmenu -cfg advmenu-gameboy.rc' },
-          { 'title': "Gameboy Advance (gpsp)", 'type': COMMAND, 'command': '/home/pi/emulators/gpsp/gpsp' },
-          { 'title': "N64 WARNING ALPHA!", 'type': COMMAND, 'command': 'advmenu -cfg advmenu-mupen.rc'},
-        ]
+#      { 'title': "Genesis (DGen)", 'type': COMMAND, 'command': 'advmenu -cfg advmenu-dgen.rc' },
+      { 'title': "Genesis (DGen)", 'type': MENU, 'subtitle': "Genesis Roms",
+         'options': build_roms_menu('genesis')
       },
+      { 'title': "SNES (PiSNES / SNES9x)", 'type': MENU, 'subtitle': "SNES Roms",
+         'options': build_roms_menu('snes')
+      },
+      { 'title': "NES (AdvanceMESS)", 'type': COMMAND, 'command': 'advmenu -cfg advmenu-nes.rc' },
+      { 'title': "Gameboy (Gearboy Advmenu)", 'type': COMMAND, 'command': 'advmenu -cfg advmenu-gameboy.rc' },
+      { 'title': "Gameboy Advance (gpsp)", 'type': COMMAND, 'command': '/home/pi/emulators/gpsp/gpsp' },
       { 'title': "Atari 2600 (Stella)", 'type': COMMAND, 'command': 'stella' },
       { 'title': "Commodore 64 (VICE)", 'type': COMMAND, 'command': 'x64' },
      ]
@@ -73,8 +143,29 @@ menu_data = {
       { 'title': "Shutdown", 'type': COMMAND, 'command': 'sudo poweroff' },
      ]
     },
+    { 'title': "Favorites", 'type': MENU, 'subtitle': 'Favorites',
+    'options': fav
+    },
   ]
 }
+
+def updown(increment, pos, optioncount):
+    global topLineNum
+    newPos = pos + increment
+
+    # paging
+    if increment == UP and pos == topLineNum and topLineNum != 0:
+        topLineNum += UP 
+        return
+    elif increment == DOWN and newPos == (curses.LINES-OFFSET+topLineNum) and (topLineNum+curses.LINES-OFFSET) != optioncount+1:
+        topLineNum += DOWN
+        return
+
+    # scroll highlight line
+#     if increment == self.UP and (self.topLineNum != 0 or self.highlightLineNum != 0):
+#         self.highlightLineNum = nextLineNum
+#     elif increment == self.DOWN and (self.topLineNum+self.highlightLineNum+1) != self.nOutputLines and self.highlightLineNum != curses.LINES:
+#         self.highlightLineNum = nextLineNum
 
 # This function displays the appropriate menu and returns the option selected
 def runmenu(menu, parent):
@@ -94,52 +185,72 @@ def runmenu(menu, parent):
   # Loop until return key is pressed
 
 
-  while x !=ord('c'):
+  while x !=ord(u'c'):
     if pos != oldpos:
       oldpos = pos
+#       screen.erase()
       screen.clear() #clears previous screen on key press and updates display based on pos
       screen.border(0)
+      
       screen.addstr(2,2, menu['title'], curses.A_STANDOUT) # Title for this menu
       screen.addstr(4,2, menu['subtitle'], curses.A_BOLD) #Subtitle for this menu
 
       # Display all the menu items, showing the 'pos' item highlighted
-      for index in range(optioncount):
+      top = topLineNum
+      bottom = min(topLineNum+curses.LINES-OFFSET, optioncount)
+      for index in range(top,bottom):
         textstyle = n
         if pos==index:
           textstyle = h
-        screen.addstr(5+index,4, "%d - %s" % (index+1, menu['options'][index]['title']), textstyle)
+        screen.addstr(5+index-top,4, "%d - %s" % (index+1, menu['options'][index]['title']), textstyle)
       # Now display Exit/Return at bottom of menu
       textstyle = n
       if pos==optioncount:
         textstyle = h
-      screen.addstr(5+optioncount,4, "%d - %s" % (optioncount+1, lastoption), textstyle)
+      if bottom == optioncount:
+        screen.addstr(5+optioncount-top,4, "%d - %s" % (optioncount+1, lastoption), textstyle)
       screen.refresh()
       # finished updating screen
 
     x = screen.getch() # Gets user input
-    if x == ord('\n'):
+    if x == ord('\n') or x == ord(' ') or x == ord('a'):
       x = ord('c')
 
     # What is user input?
-    if x >= ord('1') and x <= ord(str(optioncount+1)):
-      pos = x - ord('0') - 1 # convert keypress back to a number, then subtract 1 to get index
+    if x >= ord(u'1') and len(str(optioncount+1)) == 1 and x <= ord(str(optioncount+1)):
+      pos = x - ord(u'0') - 1 # convert keypress back to a number, then subtract 1 to get index
     elif x == 258: # down arrow
+      updown(DOWN, pos, optioncount)
       if pos < optioncount:
         pos += 1
-      else: pos = 0
+#       else: pos = 0
     elif x == 8: # down arrow
+      updown(DOWN, pos, optioncount)
       if pos < optioncount:
         pos += 1
-      else: pos = 0
+#       else: pos = 0
     elif x == 259: # up arrow
+      updown(UP, pos, optioncount)
       if pos > 0:
         pos += -1
-      else: pos = optioncount
+#       else: pos = optioncount
     elif x == 259: # up arrow
+      updown(UP, pos, optioncount)
       if pos > 0:
         pos += -1
-      else: pos = optioncount
-    elif x != ord('\n'):
+#       else: pos = optioncount
+    elif x == ord('z') or x == ord('x'):
+      is_add = True
+      if menu_data['options'][fav_idx] == menu:
+        is_add = False
+      #print(is_add)
+      need_refresh = update_favorites(menu, parent, pos, is_add)
+      if (need_refresh):
+        pos = optioncount
+        break
+      else:
+        curses.flash()
+    elif x != ord(u'\n'):
       curses.flash()
 
   # return index of the selected item
@@ -147,9 +258,11 @@ def runmenu(menu, parent):
 
 # This function calls showmenu and then acts on the selected item
 def processmenu(menu, parent=None):
+  global topLineNum
   optioncount = len(menu['options'])
   exitmenu = False
   while not exitmenu: #Loop until the user exits the menu
+    topLineNum = 0
     getin = runmenu(menu, parent)
     if getin == optioncount:
         exitmenu = True

--- a/pimame_files/menu.py
+++ b/pimame_files/menu.py
@@ -149,7 +149,7 @@ menu_data = {
   ]
 }
 
-def updown(increment, pos, optioncount):
+def scrollwindow(increment, pos, optioncount):
     global topLineNum
     newPos = pos + increment
 
@@ -169,7 +169,7 @@ def updown(increment, pos, optioncount):
 
 # This function displays the appropriate menu and returns the option selected
 def runmenu(menu, parent):
-
+  global topLineNum
   # work out what text to display as the last menu option
   if parent is None:
     lastoption = "Exit (Return to Command Line)"
@@ -185,7 +185,7 @@ def runmenu(menu, parent):
   # Loop until return key is pressed
 
 
-  while x !=ord(u'c'):
+  while x !=ord('c'):
     if pos != oldpos:
       oldpos = pos
 #       screen.erase()
@@ -217,28 +217,36 @@ def runmenu(menu, parent):
       x = ord('c')
 
     # What is user input?
-    if x >= ord(u'1') and len(str(optioncount+1)) == 1 and x <= ord(str(optioncount+1)):
-      pos = x - ord(u'0') - 1 # convert keypress back to a number, then subtract 1 to get index
+    if x >= ord('1') and len(str(optioncount+1)) == 1 and x <= ord(str(optioncount+1)):
+      pos = x - ord('0') - 1 # convert keypress back to a number, then subtract 1 to get index
     elif x == 258: # down arrow
-      updown(DOWN, pos, optioncount)
       if pos < optioncount:
+        scrollwindow(DOWN, pos, optioncount)
         pos += 1
-#       else: pos = 0
+      else:
+        pos = 0
+        topLineNum = 0
     elif x == 8: # down arrow
-      updown(DOWN, pos, optioncount)
       if pos < optioncount:
+        scrollwindow(DOWN, pos, optioncount)
         pos += 1
-#       else: pos = 0
+      else:
+        pos = 0
+        topLineNum = 0
     elif x == 259: # up arrow
-      updown(UP, pos, optioncount)
       if pos > 0:
+        scrollwindow(UP, pos, optioncount)
         pos += -1
-#       else: pos = optioncount
+      else:
+        pos = optioncount
+        topLineNum = max(optioncount - curses.LINES + OFFSET + 1, 0)
     elif x == 259: # up arrow
-      updown(UP, pos, optioncount)
       if pos > 0:
+        scrollwindow(UP, pos, optioncount)
         pos += -1
-#       else: pos = optioncount
+      else:
+        pos = optioncount
+        topLineNum = max(optioncount - curses.LINES + OFFSET + 1, 0)
     elif x == ord('z') or x == ord('x'):
       is_add = True
       if menu_data['options'][fav_idx] == menu:
@@ -250,7 +258,7 @@ def runmenu(menu, parent):
         break
       else:
         curses.flash()
-    elif x != ord(u'\n'):
+    elif x != ord('\n'):
       curses.flash()
 
   # return index of the selected item


### PR DESCRIPTION
Added features:
- Can populate rom menus directly. Implemented for SNES and Genesis, but easily extendible by adding a context entry (see EMU_CONTEXT), and a menu entry.
- Favorites menu - can add favorite roms by clicking 'z'/'x' (choice made because of my personal key mappings. Feel free to change). Similarly, pressing 'z'/'x' while in favorites will delete a rom.

Note: I used the previous menu version (without the N64) edition.
